### PR TITLE
레슨의 리뷰를 조회하는 기능 추가

### DIFF
--- a/src/main/java/com/kosa/fillinv/global/config/SecurityConfig.java
+++ b/src/main/java/com/kosa/fillinv/global/config/SecurityConfig.java
@@ -22,8 +22,9 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html",
-                                "/swagger-ui/**"
-                        ).permitAll()
+                                "/swagger-ui/**",
+                                "/api/v1/lessons/*/reviews")
+                        .permitAll()
 
                         // 그 외 모든 요청 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/com/kosa/fillinv/review/controller/ReviewController.java
+++ b/src/main/java/com/kosa/fillinv/review/controller/ReviewController.java
@@ -19,12 +19,14 @@ public class ReviewController {
 
     private final ReviewService reviewService;
 
+    private static final int MAX_PAGE_SIZE = 100;
+
     @GetMapping("/lessons/{lessonId}/reviews")
     public ResponseEntity<LessonReviewListResponseDTO> getLessonReviewList(
             @PathVariable("lessonId") String lessonId,
             @PageableDefault(size = 20) Pageable pageable) {
-        if (pageable.getPageSize() > 100) {
-            pageable = PageRequest.of(pageable.getPageNumber(), 100, pageable.getSort());
+        if (pageable.getPageSize() > MAX_PAGE_SIZE) {
+            pageable = PageRequest.of(pageable.getPageNumber(), MAX_PAGE_SIZE, pageable.getSort());
         }
         LessonReviewListResponseDTO reviewList = reviewService.getReviewListByLesson(lessonId, pageable);
         return ResponseEntity.ok(reviewList);

--- a/src/main/java/com/kosa/fillinv/review/controller/ReviewController.java
+++ b/src/main/java/com/kosa/fillinv/review/controller/ReviewController.java
@@ -1,12 +1,13 @@
 package com.kosa.fillinv.review.controller;
 
+import com.kosa.fillinv.global.response.SuccessResponse;
 import com.kosa.fillinv.review.dto.LessonReviewListResponseDTO;
 import com.kosa.fillinv.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,13 +23,13 @@ public class ReviewController {
     private static final int MAX_PAGE_SIZE = 100;
 
     @GetMapping("/lessons/{lessonId}/reviews")
-    public ResponseEntity<LessonReviewListResponseDTO> getLessonReviewList(
+    public SuccessResponse<LessonReviewListResponseDTO> getLessonReviewList(
             @PathVariable("lessonId") String lessonId,
             @PageableDefault(size = 20) Pageable pageable) {
         if (pageable.getPageSize() > MAX_PAGE_SIZE) {
             pageable = PageRequest.of(pageable.getPageNumber(), MAX_PAGE_SIZE, pageable.getSort());
         }
         LessonReviewListResponseDTO reviewList = reviewService.getReviewListByLesson(lessonId, pageable);
-        return ResponseEntity.ok(reviewList);
+        return SuccessResponse.success(HttpStatus.OK, reviewList);
     }
 }

--- a/src/main/java/com/kosa/fillinv/review/controller/ReviewController.java
+++ b/src/main/java/com/kosa/fillinv/review/controller/ReviewController.java
@@ -1,0 +1,32 @@
+package com.kosa.fillinv.review.controller;
+
+import com.kosa.fillinv.review.dto.LessonReviewListResponseDTO;
+import com.kosa.fillinv.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @GetMapping("/lessons/{lessonId}/reviews")
+    public ResponseEntity<LessonReviewListResponseDTO> getLessonReviewList(
+            @PathVariable("lessonId") String lessonId,
+            @PageableDefault(size = 20) Pageable pageable) {
+        if (pageable.getPageSize() > 100) {
+            pageable = PageRequest.of(pageable.getPageNumber(), 100, pageable.getSort());
+        }
+        LessonReviewListResponseDTO reviewList = reviewService.getReviewListByLesson(lessonId, pageable);
+        return ResponseEntity.ok(reviewList);
+    }
+}

--- a/src/main/java/com/kosa/fillinv/review/dto/LessonReviewListResponseDTO.java
+++ b/src/main/java/com/kosa/fillinv/review/dto/LessonReviewListResponseDTO.java
@@ -1,0 +1,25 @@
+package com.kosa.fillinv.review.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+public class LessonReviewListResponseDTO {
+    private Double averageScore;
+    private Long totalReviewCount;
+    private Page<LessonReviewResponseDTO> reviews;
+
+    public static LessonReviewListResponseDTO of(
+            Double averageScore,
+            Long totalReviewCount,
+            Page<LessonReviewResponseDTO> reviews
+    ) {
+        return LessonReviewListResponseDTO.builder()
+                .averageScore(averageScore != null ? averageScore : 0.0)
+                .totalReviewCount(totalReviewCount)
+                .reviews(reviews)
+                .build();
+    }
+}

--- a/src/main/java/com/kosa/fillinv/review/dto/LessonReviewResponseDTO.java
+++ b/src/main/java/com/kosa/fillinv/review/dto/LessonReviewResponseDTO.java
@@ -1,0 +1,32 @@
+package com.kosa.fillinv.review.dto;
+
+import com.kosa.fillinv.review.entity.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+public class LessonReviewResponseDTO {
+    private String reviewId;
+    private Integer score;
+    private String content;
+    private String writerId;
+    private String nickname;
+    private String lessonId;
+    private Instant createdAt;
+
+    public static LessonReviewResponseDTO from(ReviewWithNicknameVO vo) {
+        Review review = vo.getReview();
+        return LessonReviewResponseDTO.builder()
+                .reviewId(review.getId())
+                .score(review.getScore())
+                .content(review.getContent())
+                .writerId(review.getWriterId())
+                .nickname(vo.getNickname())
+                .lessonId(review.getLessonId())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/kosa/fillinv/review/dto/ReviewWithNicknameVO.java
+++ b/src/main/java/com/kosa/fillinv/review/dto/ReviewWithNicknameVO.java
@@ -1,0 +1,12 @@
+package com.kosa.fillinv.review.dto;
+
+import com.kosa.fillinv.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReviewWithNicknameVO {
+    private final Review review;
+    private final String nickname;
+}

--- a/src/main/java/com/kosa/fillinv/review/entity/Review.java
+++ b/src/main/java/com/kosa/fillinv/review/entity/Review.java
@@ -6,7 +6,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "reviews")
@@ -33,11 +33,11 @@ public class Review {
     private String scheduleId;
 
     @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     @Column(name = "deleted_at")
-    private LocalDateTime deletedAt;
+    private Instant deletedAt;
 }

--- a/src/main/java/com/kosa/fillinv/review/entity/Review.java
+++ b/src/main/java/com/kosa/fillinv/review/entity/Review.java
@@ -1,43 +1,53 @@
 package com.kosa.fillinv.review.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import com.kosa.fillinv.member.entity.Member;
+import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.Instant;
 
 @Entity
 @Table(name = "reviews")
-@Getter
 public class Review {
 
     @Id
-    @Column(name = "review_id", nullable = false)
+    @Getter
+    @Column(name = "review_id")
     private String id;
 
+    @Getter
     @Column(name = "score", nullable = false)
     private Integer score;
 
+    @Getter
     @Column(name = "content", nullable = false)
     private String content;
 
+    @Getter
     @Column(name = "writer_id", nullable = false)
     private String writerId;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", insertable = false, updatable = false)
+    private Member writer;
+
+    @Getter
     @Column(name = "lesson_id", nullable = false)
     private String lessonId;
 
+    @Getter
     @Column(name = "schedule_id", nullable = false)
     private String scheduleId;
 
+    @Getter
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
+    @Getter
     @Column(name = "updated_at")
     private Instant updatedAt;
 
+    @Getter
     @Column(name = "deleted_at")
     private Instant deletedAt;
 }

--- a/src/main/java/com/kosa/fillinv/review/entity/Review.java
+++ b/src/main/java/com/kosa/fillinv/review/entity/Review.java
@@ -1,14 +1,13 @@
 package com.kosa.fillinv.review.entity;
 
+import com.kosa.fillinv.global.entity.BaseEntity;
 import com.kosa.fillinv.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
 
-import java.time.Instant;
-
 @Entity
 @Table(name = "reviews")
-public class Review {
+public class Review extends BaseEntity {
 
     @Id
     @Getter
@@ -38,16 +37,4 @@ public class Review {
     @Getter
     @Column(name = "schedule_id", nullable = false)
     private String scheduleId;
-
-    @Getter
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
-    @Getter
-    @Column(name = "updated_at")
-    private Instant updatedAt;
-
-    @Getter
-    @Column(name = "deleted_at")
-    private Instant deletedAt;
 }

--- a/src/main/java/com/kosa/fillinv/review/entity/Review.java
+++ b/src/main/java/com/kosa/fillinv/review/entity/Review.java
@@ -1,11 +1,16 @@
 package com.kosa.fillinv.review.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "reviews")
+@Getter
 public class Review {
 
     @Id

--- a/src/main/java/com/kosa/fillinv/review/repository/ReviewRepository.java
+++ b/src/main/java/com/kosa/fillinv/review/repository/ReviewRepository.java
@@ -16,7 +16,7 @@ public interface ReviewRepository extends JpaRepository<Review, String> {
     Double findAverageScoreByLessonId(@Param("lessonId") String lessonId);
 
     @Query("SELECT new com.kosa.fillinv.review.dto.ReviewWithNicknameVO(r, m.nickname) " +
-            "FROM Review r JOIN Member m ON r.writerId = m.id " +
+            "FROM Review r LEFT JOIN Member m ON r.writerId = m.id " +
             "WHERE r.lessonId = :lessonId")
     Page<ReviewWithNicknameVO> findReviewsWithNicknameByLessonId(@Param("lessonId") String lessonId, Pageable pageable);
 

--- a/src/main/java/com/kosa/fillinv/review/repository/ReviewRepository.java
+++ b/src/main/java/com/kosa/fillinv/review/repository/ReviewRepository.java
@@ -15,8 +15,8 @@ public interface ReviewRepository extends JpaRepository<Review, String> {
     @Query("SELECT AVG(r.score) FROM Review r WHERE r.lessonId = :lessonId")
     Double findAverageScoreByLessonId(@Param("lessonId") String lessonId);
 
-    @Query("SELECT new com.kosa.fillinv.review.dto.ReviewWithNicknameVO(r, m.nickname) " +
-            "FROM Review r LEFT JOIN Member m ON r.writerId = m.id " +
+    @Query("SELECT new com.kosa.fillinv.review.dto.ReviewWithNicknameVO(r, r.writer.nickname) " +
+            "FROM Review r " +
             "WHERE r.lessonId = :lessonId")
     Page<ReviewWithNicknameVO> findReviewsWithNicknameByLessonId(@Param("lessonId") String lessonId, Pageable pageable);
 }

--- a/src/main/java/com/kosa/fillinv/review/repository/ReviewRepository.java
+++ b/src/main/java/com/kosa/fillinv/review/repository/ReviewRepository.java
@@ -19,6 +19,4 @@ public interface ReviewRepository extends JpaRepository<Review, String> {
             "FROM Review r JOIN Member m ON r.writerId = m.id " +
             "WHERE r.lessonId = :lessonId")
     Page<ReviewWithNicknameVO> findReviewsWithNicknameByLessonId(@Param("lessonId") String lessonId, Pageable pageable);
-
-    long countByLessonId(String lessonId);
 }

--- a/src/main/java/com/kosa/fillinv/review/repository/ReviewRepository.java
+++ b/src/main/java/com/kosa/fillinv/review/repository/ReviewRepository.java
@@ -1,9 +1,24 @@
 package com.kosa.fillinv.review.repository;
 
+import com.kosa.fillinv.review.dto.ReviewWithNicknameVO;
 import com.kosa.fillinv.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, String> {
+
+    @Query("SELECT AVG(r.score) FROM Review r WHERE r.lessonId = :lessonId")
+    Double findAverageScoreByLessonId(@Param("lessonId") String lessonId);
+
+    @Query("SELECT new com.kosa.fillinv.review.dto.ReviewWithNicknameVO(r, m.nickname) " +
+            "FROM Review r JOIN Member m ON r.writerId = m.id " +
+            "WHERE r.lessonId = :lessonId")
+    Page<ReviewWithNicknameVO> findReviewsWithNicknameByLessonId(@Param("lessonId") String lessonId, Pageable pageable);
+
+    long countByLessonId(String lessonId);
 }

--- a/src/main/java/com/kosa/fillinv/review/repository/ReviewRepository.java
+++ b/src/main/java/com/kosa/fillinv/review/repository/ReviewRepository.java
@@ -4,6 +4,7 @@ import com.kosa.fillinv.review.dto.ReviewWithNicknameVO;
 import com.kosa.fillinv.review.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,6 +16,7 @@ public interface ReviewRepository extends JpaRepository<Review, String> {
     @Query("SELECT AVG(r.score) FROM Review r WHERE r.lessonId = :lessonId")
     Double findAverageScoreByLessonId(@Param("lessonId") String lessonId);
 
+    @EntityGraph(attributePaths = { "writer" })
     @Query("SELECT new com.kosa.fillinv.review.dto.ReviewWithNicknameVO(r, r.writer.nickname) " +
             "FROM Review r " +
             "WHERE r.lessonId = :lessonId")

--- a/src/main/java/com/kosa/fillinv/review/service/ReviewService.java
+++ b/src/main/java/com/kosa/fillinv/review/service/ReviewService.java
@@ -1,0 +1,28 @@
+package com.kosa.fillinv.review.service;
+
+import com.kosa.fillinv.review.dto.LessonReviewListResponseDTO;
+import com.kosa.fillinv.review.dto.LessonReviewResponseDTO;
+import com.kosa.fillinv.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    @Transactional(readOnly = true)
+    public LessonReviewListResponseDTO getReviewListByLesson(String lessonId, Pageable pageable) {
+        Double averageScore = reviewRepository.findAverageScoreByLessonId(lessonId);
+        long totalCount = reviewRepository.countByLessonId(lessonId);
+        Page<LessonReviewResponseDTO> reviews = reviewRepository
+                .findReviewsWithNicknameByLessonId(lessonId, pageable)
+                .map(LessonReviewResponseDTO::from);
+
+        return LessonReviewListResponseDTO.of(averageScore, totalCount, reviews);
+    }
+}

--- a/src/main/java/com/kosa/fillinv/review/service/ReviewService.java
+++ b/src/main/java/com/kosa/fillinv/review/service/ReviewService.java
@@ -18,11 +18,10 @@ public class ReviewService {
     @Transactional(readOnly = true)
     public LessonReviewListResponseDTO getReviewListByLesson(String lessonId, Pageable pageable) {
         Double averageScore = reviewRepository.findAverageScoreByLessonId(lessonId);
-        long totalCount = reviewRepository.countByLessonId(lessonId);
         Page<LessonReviewResponseDTO> reviews = reviewRepository
                 .findReviewsWithNicknameByLessonId(lessonId, pageable)
                 .map(LessonReviewResponseDTO::from);
 
-        return LessonReviewListResponseDTO.of(averageScore, totalCount, reviews);
+        return LessonReviewListResponseDTO.of(averageScore, reviews.getTotalElements(), reviews);
     }
 }


### PR DESCRIPTION
## 🧩 작업 개요
- 레슨의 리뷰를 조회하는 기능을 추가

## 🔍 변경 내용
- `/api/v1/lessons/{lessonId}/reviews`를 인증 없이 조회 가능하게 변경
- 레슨의 리뷰를 조회할 수 있는 컨트롤러 추가
  - 관련 Response 객체 추가
- 레슨의 리뷰를 조회할 수 있는 서비스 추가
- 레슨의 리뷰를 조회할 수 있는 레포지토리 추가
  - 닉네임을 함께 가져오는 함수 추가
    - 관련 VO 추가
  - 레슨의 평점을 계산하는 함수 추가
  - 레슨의 총 리뷰를 조회하는 함수 추가
- `LocalDateTime`을 `Instant`로 수정

## ⚠️ 주의 사항
- 레포지토리 작성에 대한 의견이 궁금합니다.

## 🧪 테스트
- 없음ㅎㅎ

## 📸 스크린샷 / 로그 (선택)
- 없음

## 📎 관련 이슈
- 없음