### PR TITLE
chore: Schedule에 `lessonTitle` 추가

### DIFF
--- a/src/main/java/com/kosa/fillinv/schedule/entity/Schedule.java
+++ b/src/main/java/com/kosa/fillinv/schedule/entity/Schedule.java
@@ -31,6 +31,9 @@ public class Schedule {
     private String requestContent;
 
     /* ===== Lesson Snapshot ===== */
+    @Column(name = "lesson_title", nullable = false)
+    private String lessonTitle;
+
     @Column(name = "lesson_type", nullable = false)
     private String lessonType;
 


### PR DESCRIPTION
## 🧩 작업 개요
- Schedule 엔터티에 레슨의 제목을 저장할 수 있는 lessonTitle을 추가했습니다. 멘티가 수강을 끝낸 스케쥴에 대해 리뷰를 작성할 때 (혹은 이미 작성했을 때) 해당 레슨에 대한 정보 중 제목이 없어서 추가했습니다.
- 멘티가 자신의 리뷰를 조회했을 때, 당시 레슨의 제목을 표시할 수 있게 됩니다.

## 🔍 변경 내용
- 제곧내

## ⚠️ 주의 사항
- 없음

## 🧪 테스트
- 없음

## 📸 스크린샷 / 로그 (선택)
- 없음

## 📎 관련 이슈
- 없음
