### PR TITLE
chore: application-test의 jwt 100시간 변경

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -28,4 +28,4 @@ logging:
 
 jwt:
   secret: vmfhaltkwmdkswkdsigkdfhwldkadrhiqwudyqwiudqdw
-  expiration-time: 3600000 # 1H
+  expiration-time: 360000000 # 100H


### PR DESCRIPTION
## 🧩 작업 개요
- 개발 및 테스트 편의성을 위해 JWT Access Token 만료 시간을 100시간으로 연장

## 🔍 변경 내용
- `application-test.yml`의 `jwt.expiration-time` 값 변경
  - 기존: (기존시간)
  - 변경: 360000000 (100시간, ms 단위)
- Refresh Token 부재로 인한 빈번한 로그아웃 방지

## ⚠️ 주의 사항
- 100시간 동안 토큰이 유효하므로 토큰 탈취 시 보안 리스크가 존재함 (개발/초기 단계 감안)
- 추후 Refresh Token 도입 시 만료 시간 단축 필요