### PR TITLE
feat: Lesson 등록시 좌석수도 함께 등록

### DIFF
--- a/src/main/java/com/kosa/fillinv/lesson/controller/dto/RegisterLessonRequest.java
+++ b/src/main/java/com/kosa/fillinv/lesson/controller/dto/RegisterLessonRequest.java
@@ -13,6 +13,7 @@ public record RegisterLessonRequest(
         Long categoryId,
         Instant closeAt,
         Integer price,
+        Integer seats,
         List<Option> optionList,
         List<AvailableTime> availableTimeList
 ) {
@@ -27,6 +28,7 @@ public record RegisterLessonRequest(
                 this.categoryId,
                 this.closeAt,
                 this.price,
+                this.seats,
                 this.optionList.stream().map(Option::toCommand).toList(),
                 this.availableTimeList.stream().map(AvailableTime::toCommand).toList()
         );
@@ -38,9 +40,9 @@ public record RegisterLessonRequest(
         }
     }
 
-    public record AvailableTime(Instant startTime, Instant endTime, Integer price) {
+    public record AvailableTime(Instant startTime, Instant endTime, Integer price, Integer seats) {
         public static RegisterLessonCommand.AvailableTime toCommand(AvailableTime availableTime) {
-            return new RegisterLessonCommand.AvailableTime(availableTime.startTime, availableTime.endTime, availableTime.price);
+            return new RegisterLessonCommand.AvailableTime(availableTime.startTime, availableTime.endTime, availableTime.price, availableTime.seats);
         }
     }
 }

--- a/src/main/java/com/kosa/fillinv/lesson/entity/AvailableTime.java
+++ b/src/main/java/com/kosa/fillinv/lesson/entity/AvailableTime.java
@@ -25,6 +25,9 @@ public class AvailableTime extends BaseEntity {
     @Column(name = "price", nullable = false)
     private Integer price;
 
+    @Column(name = "seats")
+    private Integer seats;
+
     @Setter
     @ManyToOne
     @JoinColumn(name = "lesson_id", nullable = false)
@@ -35,11 +38,13 @@ public class AvailableTime extends BaseEntity {
                          Lesson lesson,
                          Instant startTime,
                          Instant endTime,
-                         Integer price) {
+                         Integer price,
+                         Integer seats) {
         this.id = id;
         this.lesson = lesson;
         this.startTime = startTime;
         this.endTime = endTime;
         this.price = price;
+        this.seats = seats;
     }
 }

--- a/src/main/java/com/kosa/fillinv/lesson/entity/Lesson.java
+++ b/src/main/java/com/kosa/fillinv/lesson/entity/Lesson.java
@@ -49,6 +49,9 @@ public class Lesson extends BaseEntity {
     @Column(name = "price")
     private Integer price;
 
+    @Column(name = "seats")
+    private Integer seats;
+
     @OneToMany(mappedBy = "lesson", cascade = CascadeType.ALL)
     private List<AvailableTime> availableTimeList;
 
@@ -65,7 +68,8 @@ public class Lesson extends BaseEntity {
                   String mentorId,
                   Long categoryId,
                   Instant closeAt,
-                  Integer price) {
+                  Integer price,
+                  Integer seats) {
         this.id = id;
         this.title = title;
         this.lessonType = lessonType;
@@ -76,6 +80,7 @@ public class Lesson extends BaseEntity {
         this.categoryId = categoryId;
         this.closeAt = closeAt;
         this.price = price;
+        this.seats = seats;
         this.availableTimeList = new ArrayList<>();
         this.optionList = new ArrayList<>();
     }

--- a/src/main/java/com/kosa/fillinv/lesson/error/LessonError.java
+++ b/src/main/java/com/kosa/fillinv/lesson/error/LessonError.java
@@ -15,4 +15,5 @@ public class LessonError {
     public static String INVALID_LESSON_TYPE(String lessonType) {
         return String.format("레슨 유형( %s )이 유효하지 않습니다.", lessonType);
     }
+    public static String INVALID_SEAT = "좌석 수는 1개 이상이어야 합니다.";
 }

--- a/src/main/java/com/kosa/fillinv/lesson/service/LessonService.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/LessonService.java
@@ -196,6 +196,9 @@ public class LessonService {
     }
 
     private AvailableTime createAvailableTimeEntity(Lesson lesson, CreateAvailableTimeCommand command) {
+        if (lesson.getLessonType() == LessonType.ONEDAY && (command.seats() == null || command.seats() <= 0)) {
+            throw new ResourceException.InvalidArgument(INVALID_SEAT);
+        }
 
         return AvailableTime.builder()
                 .id(UUID.randomUUID().toString())
@@ -237,6 +240,12 @@ public class LessonService {
             throw new ResourceException.InvalidArgument(CATEGORY_ID_REQUIRED);
         }
 
+        if (command.lessonType() == LessonType.STUDY) {
+            if (command.seats() == null || command.seats() <= 0) {
+                throw new ResourceException.InvalidArgument(INVALID_SEAT);
+            }
+        }
+
         Lesson.LessonBuilder lessonBuilder = Lesson.builder()
                 .id(UUID.randomUUID().toString())
                 .title(command.title())
@@ -246,11 +255,11 @@ public class LessonService {
                 .location(command.location())
                 .mentorId(command.mentorId())
                 .categoryId(command.categoryId())
-                .closeAt(command.closeAt())
-                .seats(command.seats());
+                .closeAt(command.closeAt());
 
         if (command.lessonType() == LessonType.STUDY) {
             lessonBuilder.price(command.price());
+            lessonBuilder.seats(command.seats());
         }
 
         return lessonBuilder.build();

--- a/src/main/java/com/kosa/fillinv/lesson/service/dto/CreateAvailableTimeCommand.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/dto/CreateAvailableTimeCommand.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 public record CreateAvailableTimeCommand(
         Instant startTime,
         Instant endTime,
-        Integer price
+        Integer price,
+        Integer seats
 ) {
 }

--- a/src/main/java/com/kosa/fillinv/lesson/service/dto/CreateLessonCommand.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/dto/CreateLessonCommand.java
@@ -15,6 +15,7 @@ public record CreateLessonCommand(
         Long categoryId,
         Instant closeAt,
         Integer price,
+        Integer seats,
         List<CreateOptionCommand> optionCommandList,
         List<CreateAvailableTimeCommand> availableTimeCommandList
 ) {

--- a/src/main/java/com/kosa/fillinv/lesson/service/dto/RegisterLessonCommand.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/dto/RegisterLessonCommand.java
@@ -15,6 +15,7 @@ public record RegisterLessonCommand(
         Long categoryId,
         Instant closeAt,
         Integer price,
+        Integer seats,
         List<Option> optionList,
         List<AvailableTime> availableTimeList
 ) {
@@ -30,14 +31,15 @@ public record RegisterLessonCommand(
                 this.categoryId,
                 this.closeAt,
                 this.price,
+                this.seats,
                 optionList.stream().map(op -> new CreateOptionCommand(op.name(), op.minute(), op.price())).toList(),
-                availableTimeList.stream().map(at -> new CreateAvailableTimeCommand(at.startTime(), at.endTime(), at.price())).toList()
+                availableTimeList.stream().map(at -> new CreateAvailableTimeCommand(at.startTime(), at.endTime(), at.price(), at.seats())).toList()
         );
     }
 
     public record Option(String name, Integer minute, Integer price) {
     }
 
-    public record AvailableTime(Instant startTime, Instant endTime, Integer price) {
+    public record AvailableTime(Instant startTime, Instant endTime, Integer price, Integer seats) {
     }
 }

--- a/src/main/java/com/kosa/fillinv/stock/entity/Stock.java
+++ b/src/main/java/com/kosa/fillinv/stock/entity/Stock.java
@@ -1,0 +1,33 @@
+package com.kosa.fillinv.stock.entity;
+
+import com.kosa.fillinv.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "stocks")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Stock extends BaseEntity {
+    @Id
+    @Column(name = "stock_id", nullable = false)
+    private String id;
+
+    @Column(name = "service_key", nullable = false)
+    private String serviceKey;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Builder
+    public Stock(String id, String serviceKey, Integer quantity) {
+        this.id = id;
+        this.serviceKey = serviceKey;
+        this.quantity = quantity;
+    }
+}

--- a/src/main/java/com/kosa/fillinv/stock/repository/StockRepository.java
+++ b/src/main/java/com/kosa/fillinv/stock/repository/StockRepository.java
@@ -1,0 +1,15 @@
+package com.kosa.fillinv.stock.repository;
+
+import com.kosa.fillinv.stock.entity.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface StockRepository extends JpaRepository<Stock, String> {
+
+    @Modifying
+    @Query("UPDATE Stock s SET s.quantity = s.quantity - 1 " +
+            "WHERE s.serviceKey = :key AND s.quantity > 0")
+    int decreaseQuantity(@Param("key") String key);
+}

--- a/src/test/java/com/kosa/fillinv/lesson/controller/LessonControllerTest.java
+++ b/src/test/java/com/kosa/fillinv/lesson/controller/LessonControllerTest.java
@@ -62,6 +62,7 @@ class LessonControllerTest {
                 1L,
                 Instant.parse("2026-02-01T23:59:59Z"),
                 30000,
+                5,
                 List.of(),
                 List.of()
         );

--- a/src/test/java/com/kosa/fillinv/lesson/repository/LessonRepositoryTest.java
+++ b/src/test/java/com/kosa/fillinv/lesson/repository/LessonRepositoryTest.java
@@ -39,9 +39,9 @@ class LessonRepositoryTest {
         Lesson lesson = createLesson(lessonId);
         List<Option> optionList = List.of(new Option("option-001", "option1", 30, 1000, lesson));
         List<AvailableTime> availableTimeList = List.of(
-                new AvailableTime("at-001", lesson, Instant.now(), Instant.now(), 10000),
-                new AvailableTime("at-002", lesson, Instant.now(), Instant.now(), 20000),
-                new AvailableTime("at-003", lesson, Instant.now(), Instant.now(), 30000)
+                new AvailableTime("at-001", lesson, Instant.now(), Instant.now(), 10000, 1),
+                new AvailableTime("at-002", lesson, Instant.now(), Instant.now(), 20000, 2),
+                new AvailableTime("at-003", lesson, Instant.now(), Instant.now(), 30000, 3)
         );
 
         lesson.addAvailableTime(availableTimeList);
@@ -70,7 +70,8 @@ class LessonRepositoryTest {
                 "mentor-1",
                 1L,
                 Instant.now().truncatedTo(ChronoUnit.SECONDS).plus(7, ChronoUnit.DAYS),
-                10000
+                10000,
+                null
         );
     }
 }

--- a/src/test/java/com/kosa/fillinv/lesson/service/LessonReadServiceIntegrationTest.java
+++ b/src/test/java/com/kosa/fillinv/lesson/service/LessonReadServiceIntegrationTest.java
@@ -44,9 +44,9 @@ public class LessonReadServiceIntegrationTest {
         Lesson lesson = createLesson(lessonId);
         List<Option> optionList = List.of(new Option("option-001", "option1", 30, 1000, lesson));
         List<AvailableTime> availableTimeList = List.of(
-                new AvailableTime("at-001", lesson, Instant.now(), Instant.now(), 10000),
-                new AvailableTime("at-002", lesson, Instant.now(), Instant.now(), 20000),
-                new AvailableTime("at-003", lesson, Instant.now(), Instant.now(), 30000)
+                new AvailableTime("at-001", lesson, Instant.now(), Instant.now(), 10000, 1),
+                new AvailableTime("at-002", lesson, Instant.now(), Instant.now(), 20000, 2),
+                new AvailableTime("at-003", lesson, Instant.now(), Instant.now(), 30000, 3)
         );
 
         lesson.addAvailableTime(availableTimeList);
@@ -73,7 +73,8 @@ public class LessonReadServiceIntegrationTest {
                 "mentor-1",
                 1L,
                 Instant.now().truncatedTo(ChronoUnit.SECONDS).plus(7, ChronoUnit.DAYS),
-                10000
+                10000,
+                null
         );
     }
 }

--- a/src/test/java/com/kosa/fillinv/lesson/service/LessonRegisterServiceTest.java
+++ b/src/test/java/com/kosa/fillinv/lesson/service/LessonRegisterServiceTest.java
@@ -95,6 +95,7 @@ class LessonRegisterServiceTest {
                 1L,
                 Instant.parse("2025-01-31T23:59:59Z"),
                 null,
+                null,
                 List.of(),
                 List.of()
         );
@@ -127,6 +128,7 @@ class LessonRegisterServiceTest {
                 1L,                          // categoryId
                 Instant.parse("2025-01-31T23:59:59Z"), // closeAt
                 null,                        // price (레슨 전체 가격, 필요 없으면 null)
+                null,
                 List.of(
                         new RegisterLessonCommand.Option("30분 멘토링", 30, 30000),
                         new RegisterLessonCommand.Option("60분 멘토링", 60, 55000)
@@ -135,12 +137,14 @@ class LessonRegisterServiceTest {
                         new RegisterLessonCommand.AvailableTime(
                                 Instant.parse("2025-01-10T05:00:00Z"),
                                 Instant.parse("2025-01-10T07:00:00Z"),
-                                50000
+                                50000,
+                                null
                         ),
                         new RegisterLessonCommand.AvailableTime(
                                 Instant.parse("2025-01-17T05:00:00Z"),
                                 Instant.parse("2025-01-17T07:00:00Z"),
-                                50000
+                                50000,
+                                null
                         )
                 )
         );

--- a/src/test/java/com/kosa/fillinv/lesson/service/LessonServiceTest.java
+++ b/src/test/java/com/kosa/fillinv/lesson/service/LessonServiceTest.java
@@ -595,6 +595,7 @@ class LessonServiceTest {
                 1L,
                 Instant.now().truncatedTo(ChronoUnit.SECONDS).plus(7, ChronoUnit.DAYS),
                 null,
+                null,
                 List.of(createOptionCommand("option1", 30, 1000), createOptionCommand("option2", 60, 2000)),
                 List.of(createAvailableTimeCommand())
         );
@@ -605,7 +606,8 @@ class LessonServiceTest {
         return new CreateAvailableTimeCommand(
                 now,
                 now.plus(2, ChronoUnit.HOURS),
-                10000
+                10000,
+                1
         );
     }
 
@@ -616,7 +618,8 @@ class LessonServiceTest {
         return new CreateAvailableTimeCommand(
                 startTime,
                 endTime,
-                price
+                price,
+                2
         );
     }
 
@@ -641,6 +644,7 @@ class LessonServiceTest {
                 categoryId,
                 Instant.now().truncatedTo(ChronoUnit.SECONDS).plus(1, ChronoUnit.DAYS),
                 null,
+                3,
                 optionList,
                 availableTimeList
         );

--- a/src/test/java/com/kosa/fillinv/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/kosa/fillinv/schedule/service/ScheduleServiceTest.java
@@ -139,7 +139,8 @@ class ScheduleServiceTest {
                         lesson,
                         Instant.parse("2025-02-01T09:00:00Z"),
                         Instant.parse("2025-02-01T12:00:00Z"),
-                        50000
+                        50000,
+                        5
                 )
         );
 
@@ -196,13 +197,15 @@ class ScheduleServiceTest {
                         lesson,
                         Instant.parse("2025-03-01T10:00:00Z"),
                         Instant.parse("2025-03-01T12:00:00Z"),
-                        0),
+                        0,
+                        5),
                 new AvailableTime(
                         "at-2",
                         lesson,
                         Instant.parse("2025-03-08T10:00:00Z"),
                         Instant.parse("2025-03-08T12:00:00Z"),
-                        0)
+                        0,
+                        6)
         ));
 
         ScheduleCreateRequest request = new ScheduleCreateRequest(


### PR DESCRIPTION
## 🧩 작업 개요
- 레슨을 등록할 때 좌석수를 함께 등록하는 로직 구현

## 🔍 변경 내용
- 엔터티에 seats 추가 (1:N스터디: Lesson 엔터티, 1:N 원데이: AvailableTime 엔터티)
- 남은 좌석 수를 나타낼 수 있는 Stock 엔터티 추가
  - StockRepository 추가
- Lesson 등록시 좌석수에 맞게 Stock 엔터티 생성
- Lesson 등록 request에 최대 좌석수 seats 추가

## ⚠️ 주의 사항
- LessonService를 수정해 Stock을 함께 생성하게 했는데 올바르게 했는지 확인 부탁드립니다.
- 레슨 타입에 따른 seats 컬럼에 대한 널 처리를 어떻게 할지가 좀 애매하네요. 멘토링 같은 경우는 seats가 없는데 0으로 둘지, null로 둘지 그런 점이요.

## 🧪 테스트
- ㅋㅋ

## 📸 스크린샷 / 로그 (선택)
- 없음

## 📎 관련 이슈
- 없음
