### PR TITLE
Fix : Lesson 조회 시 누락된 필드 추가, category 이름 응답에 추가

### DIFF
--- a/src/main/java/com/kosa/fillinv/category/service/CategoryService.java
+++ b/src/main/java/com/kosa/fillinv/category/service/CategoryService.java
@@ -3,6 +3,7 @@ package com.kosa.fillinv.category.service;
 import com.kosa.fillinv.category.dto.CategoryResponseDto;
 import com.kosa.fillinv.category.entity.Category;
 import com.kosa.fillinv.category.repository.CategoryRepository;
+import com.kosa.fillinv.global.exception.ResourceException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,5 +35,10 @@ public class CategoryService {
                         Category::getId,
                         CategoryResponseDto::of
                 ));
+    }
+
+    public Category getCategoryById(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new ResourceException.NotFound("카테고리를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/kosa/fillinv/lesson/service/LessonReadService.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/LessonReadService.java
@@ -59,7 +59,8 @@ public class LessonReadService {
         return lessonPage.map(lesson -> {
             MentorSummaryDTO mentor = mentorMap.get(lesson.mentorId());
             Float rating = averageRating.get(lesson.id());
-            return LessonThumbnail.of(lesson, mentor, rating, allCategoriesMap.get(lesson.categoryId()).name());
+            return LessonThumbnail.of(lesson, mentor, rating,
+                    allCategoriesMap.get(lesson.categoryId()) == null ? null : allCategoriesMap.get(lesson.categoryId()).name());
         });
     }
 

--- a/src/main/java/com/kosa/fillinv/lesson/service/LessonReadService.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/LessonReadService.java
@@ -1,5 +1,8 @@
 package com.kosa.fillinv.lesson.service;
 
+import com.kosa.fillinv.category.dto.CategoryResponseDto;
+import com.kosa.fillinv.category.entity.Category;
+import com.kosa.fillinv.category.service.CategoryService;
 import com.kosa.fillinv.global.exception.ResourceException;
 import com.kosa.fillinv.lesson.entity.LessonType;
 import com.kosa.fillinv.lesson.service.client.MentorSummaryDTO;
@@ -30,6 +33,8 @@ public class LessonReadService {
 
     private final StockClient stockClient;
 
+    private final CategoryService categoryService;
+
     public Page<LessonThumbnail> search() {
         return search(LessonSearchCondition.defaultCondition());
     }
@@ -38,6 +43,8 @@ public class LessonReadService {
         condition = condition == null ? LessonSearchCondition.defaultCondition() : condition;
 
         Page<LessonDTO> lessonPage = lessonService.searchLesson(condition);
+
+        Map<Long, CategoryResponseDto> allCategoriesMap = categoryService.getAllCategoriesMap();
 
         Set<String> mentorIds = lessonPage.stream()
                 .map(LessonDTO::mentorId)
@@ -52,7 +59,7 @@ public class LessonReadService {
         return lessonPage.map(lesson -> {
             MentorSummaryDTO mentor = mentorMap.get(lesson.mentorId());
             Float rating = averageRating.get(lesson.id());
-            return LessonThumbnail.of(lesson, mentor, rating);
+            return LessonThumbnail.of(lesson, mentor, rating, allCategoriesMap.get(lesson.categoryId()).name());
         });
     }
 
@@ -62,6 +69,8 @@ public class LessonReadService {
                 .orElseThrow(() -> new ResourceException.NotFound(LESSON_NOT_FOUND_MESSAGE_FORMAT(request.lessonId())));
 
         MentorSummaryDTO mentorSummaryDTO = profileClient.readMentorById(lessonDTO.mentorId());
+
+        Category category = categoryService.getCategoryById(lessonDTO.categoryId());
 
         Set<String> keys = Set.of();
         if (lessonDTO.lessonType() == LessonType.STUDY) {
@@ -89,6 +98,6 @@ public class LessonReadService {
             availableTimeRemainSeats = stockMap;
         }
 
-        return LessonDetailResult.of(mentorSummaryDTO, lessonDTO, lessonRemainSeats, availableTimeRemainSeats);
+        return LessonDetailResult.of(mentorSummaryDTO, lessonDTO, lessonRemainSeats, availableTimeRemainSeats, category.getName());
     }
 }

--- a/src/main/java/com/kosa/fillinv/lesson/service/dto/LessonDetailResult.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/dto/LessonDetailResult.java
@@ -10,16 +10,18 @@ public record LessonDetailResult(
         Mentor mentor,
         Lesson lesson,
         List<Option> options,
-        List<AvailableTime> availableTimes) {
+        List<AvailableTime> availableTimes
+) {
     public static LessonDetailResult of(
             MentorSummaryDTO mentorSummaryDTO,
             LessonDTO lessonDTO,
             Integer lessonRemainSeats,
-            Map<String, Integer> availableTimeRemainSeats
+            Map<String, Integer> availableTimeRemainSeats,
+            String categoryName
     ) {
         return new LessonDetailResult(
                 Mentor.of(mentorSummaryDTO),
-                Lesson.of(lessonDTO, lessonRemainSeats),
+                Lesson.of(lessonDTO, lessonRemainSeats, categoryName),
                 lessonDTO.optionDTOList().stream().map(Option::of).toList(),
                 lessonDTO.availableTimeDTOList().stream()
                         .map(dt -> AvailableTime.of(dt, availableTimeRemainSeats != null ? availableTimeRemainSeats.get(dt.id()) : null))
@@ -51,9 +53,12 @@ public record LessonDetailResult(
             Integer price,
             Integer seats,
             Integer remainSeats,
-            Long categoryId
+            Long categoryId,
+            String location,
+            Instant closeAt,
+            String category
     ) {
-        public static Lesson of(LessonDTO lessonDTO, Integer remainSeats) {
+        public static Lesson of(LessonDTO lessonDTO, Integer remainSeats, String categoryName) {
             return new Lesson(
                     lessonDTO.id(),
                     lessonDTO.description(),
@@ -63,7 +68,11 @@ public record LessonDetailResult(
                     lessonDTO.price(),
                     lessonDTO.seats(),
                     remainSeats,
-                    lessonDTO.categoryId());
+                    lessonDTO.categoryId(),
+                    lessonDTO.location(),
+                    lessonDTO.closeAt(),
+                    categoryName
+            );
         }
     }
 

--- a/src/main/java/com/kosa/fillinv/lesson/service/dto/LessonThumbnail.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/dto/LessonThumbnail.java
@@ -9,9 +9,14 @@ public record LessonThumbnail(
         String lessonType,
         String mentorNickName,
         Float rating,
-        Long categoryId
+        Long categoryId,
+        String category
 ) {
-    public static LessonThumbnail of(LessonDTO lesson, MentorSummaryDTO mentor, Float rating) {
+    public static LessonThumbnail of(
+            LessonDTO lesson,
+            MentorSummaryDTO mentor,
+            Float rating,
+            String category) {
         return new LessonThumbnail(
                 lesson.id(),
                 lesson.thumbnailImage(),
@@ -19,7 +24,8 @@ public record LessonThumbnail(
                 lesson.lessonType().name(),
                 mentor.nickname(),
                 rating,
-                lesson.categoryId()
+                lesson.categoryId(),
+                category
         );
     }
 }


### PR DESCRIPTION
## 🧩 작업 개요
Lesson 조회 시 누락된 필드 추가, category 이름 응답에 추가 

## 🔍 변경 내용
- 레슨 상세 정보 조회시 location, closeAt 필드가 누락된 것을 수정
- 레슨 목록 조회, 레슨 상세 조회 시 categoryId만 포함되던 것은 category 필드를 추가해서 이름도 함께 반환

## ⚠️ 주의 사항

## 🧪 테스트
- [ ] 단위 테스트
- [ ] 통합 테스트
- [x] 수동 테스트

## 📸 스크린샷 / 로그 (선택)

- 목록 조회
<img width="1010" height="525" alt="image" src="https://github.com/user-attachments/assets/43fc1a42-c432-4fb0-8c5d-83508219f746" />

- 상세 조회
<img width="1023" height="645" alt="image" src="https://github.com/user-attachments/assets/7d3eed36-409e-48ef-89b5-ca00b77ebcd2" />


