### PR TITLE
fix: 레슨 등록 시 최소 가격 저장

### DIFF
--- a/src/main/java/com/kosa/fillinv/lesson/entity/Lesson.java
+++ b/src/main/java/com/kosa/fillinv/lesson/entity/Lesson.java
@@ -178,4 +178,8 @@ public class Lesson extends BaseEntity {
             throw new ResourceException.AccessDenied("해당 레슨에 대한 권한이 없습니다.");
         }
     }
+
+    public void updateMinPrice(int minPrice) {
+        this.price = minPrice;
+    }
 }

--- a/src/main/java/com/kosa/fillinv/lesson/service/LessonService.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/LessonService.java
@@ -62,6 +62,14 @@ public class LessonService {
             stockRepository.save(createStockEntityForStudyLesson(saved));
         }
 
+        if (saved.getLessonType() == LessonType.MENTORING) {
+            int minPrice = saved.getOptionList().stream().mapToInt(Option::getPrice).min().orElse(0);
+            saved.updateMinPrice(minPrice);
+        } else if (saved.getLessonType() == LessonType.ONEDAY) {
+            int minPrice = saved.getAvailableTimeList().stream().mapToInt(AvailableTime::getPrice).min().orElse(0);
+            saved.updateMinPrice(minPrice);
+        }
+
         return CreateLessonResult.of(saved);
     }
 


### PR DESCRIPTION
## 🧩 작업 개요
- 레슨이 등록될 때 멘토링/원데이도 Lesson의 price 필드에 기본 가격을 저장합니다.
- 기본 가격은 멘토링은 옵션 중 최저가, 원데이는 회차 중 최저가 입니다.

## 🔍 변경 내용
- LessonService에서 createLesson 메소드가 기본 가격을 lesson 객체에 주입하도록 변경하였습니다.
- Lesson 엔티티에 price를 세팅할 수 있는 updateMinPrice 메소드를 추가하였습니다.

## ⚠️ 주의 사항


## 🧪 테스트


## 📸 스크린샷 / 로그 (선택)


## 📎 관련 이슈

