### PR TITLE
feat: 1:1 멘토링 레슨 조회시 이미 예약된 시간 함께 조회

### DIFF
--- a/src/main/java/com/kosa/fillinv/lesson/service/LessonReadService.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/LessonReadService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,6 +38,8 @@ public class LessonReadService {
     private final ScheduleClient scheduleClient;
 
     private static final Set<ScheduleStatus> PARTICIPATED_STATUSES = Set.of(ScheduleStatus.APPROVED, ScheduleStatus.COMPLETED);
+
+    private static final Set<ScheduleStatus> MENTORING_BOOKED_STATUES = Set.of(ScheduleStatus.PAYMENT_PENDING, ScheduleStatus.APPROVAL_PENDING, ScheduleStatus.APPROVED);
 
     public Page<LessonThumbnail> search() {
         return search(LessonSearchRequest.empty());
@@ -126,13 +129,19 @@ public class LessonReadService {
                 PARTICIPATED_STATUSES
         );
 
+        List<BookedTimeVO> bookedTimes = null;
+        if (lessonDTO.lessonType() == LessonType.MENTORING) {
+            bookedTimes = scheduleClient.getBookedTimes(request.lessonId(), MENTORING_BOOKED_STATUES);
+        }
+
         return LessonDetailResult.of(
                 mentorSummaryDTO,
                 lessonDTO,
                 lessonRemainSeats,
                 availableTimeRemainSeats,
                 category.getName(),
-                menteeCount == null ? 0 : menteeCount
+                menteeCount == null ? 0 : menteeCount,
+                bookedTimes
         );
     }
 

--- a/src/main/java/com/kosa/fillinv/lesson/service/LessonReadService.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/LessonReadService.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -131,7 +133,11 @@ public class LessonReadService {
 
         List<BookedTimeVO> bookedTimes = null;
         if (lessonDTO.lessonType() == LessonType.MENTORING) {
-            bookedTimes = scheduleClient.getBookedTimes(request.lessonId(), MENTORING_BOOKED_STATUES);
+            bookedTimes = scheduleClient.getBookedTimes(
+                    request.lessonId(),
+                    MENTORING_BOOKED_STATUES,
+                    Instant.now().minus(7, ChronoUnit.DAYS) // 모든 schedule_time을 가져오지 않게
+            );
         }
 
         return LessonDetailResult.of(

--- a/src/main/java/com/kosa/fillinv/lesson/service/client/DefaultScheduleClient.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/client/DefaultScheduleClient.java
@@ -7,6 +7,7 @@ import com.kosa.fillinv.schedule.repository.ScheduleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +38,7 @@ public class DefaultScheduleClient implements ScheduleClient {
     }
 
     @Override
-    public List<BookedTimeVO> getBookedTimes(String lessonId, Collection<ScheduleStatus> statuses) {
-        return scheduleRepository.findBookedTimesByLessonIdAndStatusIn(lessonId, statuses);
+    public List<BookedTimeVO> getBookedTimes(String lessonId, Collection<ScheduleStatus> statuses, Instant since) {
+        return scheduleRepository.findBookedTimesByLessonIdAndStatusInAndStartTimeAfter(lessonId, statuses, since);
     }
 }

--- a/src/main/java/com/kosa/fillinv/lesson/service/client/DefaultScheduleClient.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/client/DefaultScheduleClient.java
@@ -1,5 +1,6 @@
 package com.kosa.fillinv.lesson.service.client;
 
+import com.kosa.fillinv.lesson.service.dto.BookedTimeVO;
 import com.kosa.fillinv.lesson.service.dto.LessonCountVO;
 import com.kosa.fillinv.schedule.entity.ScheduleStatus;
 import com.kosa.fillinv.schedule.repository.ScheduleRepository;
@@ -7,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -32,5 +34,10 @@ public class DefaultScheduleClient implements ScheduleClient {
     public Integer countByLessonIdAndStatusIn(String lessonId, Collection<ScheduleStatus> statuses) {
         Long count = scheduleRepository.countByLessonIdAndStatusIn(lessonId, statuses);
         return count != null ? count.intValue() : 0;
+    }
+
+    @Override
+    public List<BookedTimeVO> getBookedTimes(String lessonId, Collection<ScheduleStatus> statuses) {
+        return scheduleRepository.findBookedTimesByLessonIdAndStatusIn(lessonId, statuses);
     }
 }

--- a/src/main/java/com/kosa/fillinv/lesson/service/client/ScheduleClient.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/client/ScheduleClient.java
@@ -1,8 +1,10 @@
 package com.kosa.fillinv.lesson.service.client;
 
+import com.kosa.fillinv.lesson.service.dto.BookedTimeVO;
 import com.kosa.fillinv.schedule.entity.ScheduleStatus;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public interface ScheduleClient {
@@ -10,4 +12,6 @@ public interface ScheduleClient {
             Collection<ScheduleStatus> statuses);
 
     Integer countByLessonIdAndStatusIn(String lessonId, Collection<ScheduleStatus> statuses);
+
+    List<BookedTimeVO> getBookedTimes(String lessonId, Collection<ScheduleStatus> statuses);
 }

--- a/src/main/java/com/kosa/fillinv/lesson/service/client/ScheduleClient.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/client/ScheduleClient.java
@@ -3,6 +3,7 @@ package com.kosa.fillinv.lesson.service.client;
 import com.kosa.fillinv.lesson.service.dto.BookedTimeVO;
 import com.kosa.fillinv.schedule.entity.ScheduleStatus;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -13,5 +14,5 @@ public interface ScheduleClient {
 
     Integer countByLessonIdAndStatusIn(String lessonId, Collection<ScheduleStatus> statuses);
 
-    List<BookedTimeVO> getBookedTimes(String lessonId, Collection<ScheduleStatus> statuses);
+    List<BookedTimeVO> getBookedTimes(String lessonId, Collection<ScheduleStatus> statuses, Instant since);
 }

--- a/src/main/java/com/kosa/fillinv/lesson/service/dto/BookedTimeVO.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/dto/BookedTimeVO.java
@@ -1,0 +1,9 @@
+package com.kosa.fillinv.lesson.service.dto;
+
+import java.time.Instant;
+
+public record BookedTimeVO(
+        Instant startTime,
+        Instant endTime
+) {
+}

--- a/src/main/java/com/kosa/fillinv/lesson/service/dto/LessonDetailResult.java
+++ b/src/main/java/com/kosa/fillinv/lesson/service/dto/LessonDetailResult.java
@@ -10,7 +10,8 @@ public record LessonDetailResult(
         Mentor mentor,
         Lesson lesson,
         List<Option> options,
-        List<AvailableTime> availableTimes
+        List<AvailableTime> availableTimes,
+        List<BookedTime> bookedTimes
 ) {
     public static LessonDetailResult of(
             MentorSummaryDTO mentorSummaryDTO,
@@ -18,7 +19,8 @@ public record LessonDetailResult(
             Integer lessonRemainSeats,
             Map<String, Integer> availableTimeRemainSeats,
             String categoryName,
-            Integer menteeCount
+            Integer menteeCount,
+            List<BookedTimeVO> bookedTimes
     ) {
         return new LessonDetailResult(
                 Mentor.of(mentorSummaryDTO),
@@ -26,7 +28,8 @@ public record LessonDetailResult(
                 lessonDTO.optionDTOList().stream().map(Option::of).toList(),
                 lessonDTO.availableTimeDTOList().stream()
                         .map(dt -> AvailableTime.of(dt, availableTimeRemainSeats != null ? availableTimeRemainSeats.get(dt.id()) : null))
-                        .toList());
+                        .toList(),
+                bookedTimes != null ? bookedTimes.stream().map(BookedTime::of).toList() : null);
     }
 
     public record Mentor(
@@ -111,6 +114,17 @@ public record LessonDetailResult(
                     availableTimeDTO.price(),
                     availableTimeDTO.seats(),
                     remainSeats);
+        }
+    }
+
+    public record BookedTime(
+            Instant startTime,
+            Instant endTime
+    ) {
+        public static BookedTime of(BookedTimeVO vo) {
+            return new BookedTime(
+                    vo.startTime(),
+                    vo.endTime());
         }
     }
 }

--- a/src/main/java/com/kosa/fillinv/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/kosa/fillinv/schedule/repository/ScheduleRepository.java
@@ -11,10 +11,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
-import java.util.List;
-
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 
 @Repository
@@ -52,4 +50,11 @@ public interface ScheduleRepository extends JpaRepository<Schedule, String> {
 
     @Query("SELECT s.lessonId, COUNT(s) FROM Schedule s JOIN Lesson l ON s.lessonId = l.id WHERE s.createdAt >= :startDate AND s.deletedAt IS NULL AND l.deletedAt IS NULL GROUP BY s.lessonId")
     List<Object[]> countByLessonIdAndCreatedAtAfter(@Param("startDate") Instant startDate);
+
+    @Query("SELECT new com.kosa.fillinv.lesson.service.dto.BookedTimeVO(st.startTime, st.endTime) " +
+            "FROM Schedule s " +
+            "JOIN s.scheduleTimeList st " +
+            "WHERE s.lessonId = :lessonId AND s.status IN :statuses")
+    List<com.kosa.fillinv.lesson.service.dto.BookedTimeVO> findBookedTimesByLessonIdAndStatusIn(
+            @Param("lessonId") String lessonId, @Param("statuses") Collection<ScheduleStatus> statuses);
 }

--- a/src/main/java/com/kosa/fillinv/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/kosa/fillinv/schedule/repository/ScheduleRepository.java
@@ -1,5 +1,6 @@
 package com.kosa.fillinv.schedule.repository;
 
+import com.kosa.fillinv.lesson.service.dto.BookedTimeVO;
 import com.kosa.fillinv.lesson.service.dto.LessonCountVO;
 import com.kosa.fillinv.review.dto.UnwrittenReviewVO;
 import com.kosa.fillinv.schedule.entity.Schedule;
@@ -55,6 +56,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, String> {
             "FROM Schedule s " +
             "JOIN s.scheduleTimeList st " +
             "WHERE s.lessonId = :lessonId AND s.status IN :statuses")
-    List<com.kosa.fillinv.lesson.service.dto.BookedTimeVO> findBookedTimesByLessonIdAndStatusIn(
-            @Param("lessonId") String lessonId, @Param("statuses") Collection<ScheduleStatus> statuses);
+    List<BookedTimeVO> findBookedTimesByLessonIdAndStatusIn(@Param("lessonId") String lessonId, @Param("statuses") Collection<ScheduleStatus> statuses);
 }

--- a/src/main/java/com/kosa/fillinv/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/kosa/fillinv/schedule/repository/ScheduleRepository.java
@@ -55,6 +55,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, String> {
     @Query("SELECT new com.kosa.fillinv.lesson.service.dto.BookedTimeVO(st.startTime, st.endTime) " +
             "FROM Schedule s " +
             "JOIN s.scheduleTimeList st " +
-            "WHERE s.lessonId = :lessonId AND s.status IN :statuses")
-    List<BookedTimeVO> findBookedTimesByLessonIdAndStatusIn(@Param("lessonId") String lessonId, @Param("statuses") Collection<ScheduleStatus> statuses);
+            "WHERE s.lessonId = :lessonId AND s.status IN :statuses AND st.startTime >= :since")
+    List<BookedTimeVO> findBookedTimesByLessonIdAndStatusInAndStartTimeAfter(@Param("lessonId") String lessonId, @Param("statuses") Collection<ScheduleStatus> statuses, @Param("since") Instant since);
 }


### PR DESCRIPTION
## 🧩 작업 개요
- 제목

## 🔍 변경 내용 
- 멘토링 레슨 상세 조회 결과에 이미 예약된 시간 정보 추가
- 관련해 ScheduleRepository에 schedule_time을 조회하는 함수 추가
- 관련해 해당 함수 호출하는 Client 함수 정의 및 구현

## ⚠️ 주의 사항
- schedule_time을 이런식으로 조회하면 될까요

## 🧪 테스트
-

## 📸 스크린샷 / 로그 (선택)
<img width="997" height="374" alt="image" src="https://github.com/user-attachments/assets/3287a18f-759b-4e12-8e92-61dc90418031" />
빨간게 이미 예약된 구간입니다

## 📎 관련 이슈
- 